### PR TITLE
WIP: Changes to reflect the fact that Provide/FindProviders use multihashes.

### DIFF
--- a/mock/centralized_client.go
+++ b/mock/centralized_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	peer "github.com/libp2p/go-libp2p-peer"
 	pstore "github.com/libp2p/go-libp2p-peerstore"
@@ -12,6 +11,7 @@ import (
 	ropts "github.com/libp2p/go-libp2p-routing/options"
 	"github.com/libp2p/go-testutil"
 	ma "github.com/multiformats/go-multiaddr"
+	mh "github.com/multiformats/go-multihash"
 )
 
 var log = logging.Logger("mockrouter")
@@ -34,7 +34,7 @@ func (c *client) GetValue(ctx context.Context, key string, opts ...ropts.Option)
 	return c.vs.GetValue(ctx, key, opts...)
 }
 
-func (c *client) FindProviders(ctx context.Context, key cid.Cid) ([]pstore.PeerInfo, error) {
+func (c *client) FindProviders(ctx context.Context, key mh.Multihash) ([]pstore.PeerInfo, error) {
 	return c.server.Providers(key), nil
 }
 
@@ -43,7 +43,7 @@ func (c *client) FindPeer(ctx context.Context, pid peer.ID) (pstore.PeerInfo, er
 	return pstore.PeerInfo{}, nil
 }
 
-func (c *client) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan pstore.PeerInfo {
+func (c *client) FindProvidersAsync(ctx context.Context, k mh.Multihash, max int) <-chan pstore.PeerInfo {
 	out := make(chan pstore.PeerInfo)
 	go func() {
 		defer close(out)
@@ -63,7 +63,7 @@ func (c *client) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-c
 
 // Provide returns once the message is on the network. Value is not necessarily
 // visible yet.
-func (c *client) Provide(_ context.Context, key cid.Cid, brd bool) error {
+func (c *client) Provide(_ context.Context, key mh.Multihash, brd bool) error {
 	if !brd {
 		return nil
 	}

--- a/none/none_client.go
+++ b/none/none_client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 
-	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	p2phost "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -13,6 +12,7 @@ import (
 	record "github.com/libp2p/go-libp2p-record"
 	routing "github.com/libp2p/go-libp2p-routing"
 	ropts "github.com/libp2p/go-libp2p-routing/options"
+	mh "github.com/multiformats/go-multihash"
 )
 
 type nilclient struct {
@@ -30,13 +30,13 @@ func (c *nilclient) FindPeer(_ context.Context, _ peer.ID) (pstore.PeerInfo, err
 	return pstore.PeerInfo{}, nil
 }
 
-func (c *nilclient) FindProvidersAsync(_ context.Context, _ cid.Cid, _ int) <-chan pstore.PeerInfo {
+func (c *nilclient) FindProvidersAsync(_ context.Context, _ mh.Multihash, _ int) <-chan pstore.PeerInfo {
 	out := make(chan pstore.PeerInfo)
 	defer close(out)
 	return out
 }
 
-func (c *nilclient) Provide(_ context.Context, _ cid.Cid, _ bool) error {
+func (c *nilclient) Provide(_ context.Context, _ mh.Multihash, _ bool) error {
 	return nil
 }
 

--- a/offline/offline.go
+++ b/offline/offline.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	proto "github.com/gogo/protobuf/proto"
-	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	dshelp "github.com/ipfs/go-ipfs-ds-help"
 	"github.com/libp2p/go-libp2p-peer"
@@ -18,6 +17,7 @@ import (
 	pb "github.com/libp2p/go-libp2p-record/pb"
 	routing "github.com/libp2p/go-libp2p-routing"
 	ropts "github.com/libp2p/go-libp2p-routing/options"
+	mh "github.com/multiformats/go-multihash"
 )
 
 // ErrOffline is returned when trying to perform operations that
@@ -94,13 +94,13 @@ func (c *offlineRouting) FindPeer(ctx context.Context, pid peer.ID) (pstore.Peer
 	return pstore.PeerInfo{}, ErrOffline
 }
 
-func (c *offlineRouting) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan pstore.PeerInfo {
+func (c *offlineRouting) FindProvidersAsync(ctx context.Context, k mh.Multihash, max int) <-chan pstore.PeerInfo {
 	out := make(chan pstore.PeerInfo)
 	close(out)
 	return out
 }
 
-func (c *offlineRouting) Provide(_ context.Context, k cid.Cid, _ bool) error {
+func (c *offlineRouting) Provide(_ context.Context, k mh.Multihash, _ bool) error {
 	return ErrOffline
 }
 


### PR DESCRIPTION
See https://github.com/libp2p/go-libp2p-routing/pull/33